### PR TITLE
DEV: add github action for standard python build

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 ./please --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 ./please --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        python -m unittest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,12 +32,12 @@ jobs:
     - name: Install development environment with Poetry
       run: |
         poetry install
-    - name: Lint with flake8
+    - name: Lint with flake8 inside the development environment
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 ./please --count --select=E9,F63,F7,F82 --show-source --statistics
+        poetry run flake8 ./please --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 ./please --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Execute unittests
+        poetry run flake8 ./please --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Execute unittests in the development environment
       run: |
-        python -m unittest
+        poetry run python -m unittest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,14 +27,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8
+        python -m pip install flake8 poetry
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Install development environment with Poetry
+      run: |
+        poetry install
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 ./please --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 ./please --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Execute unittests
       run: |
         python -m unittest


### PR DESCRIPTION
This PR introduces a Github Action to run a minimal set of CI tasks for the code in this repository, namely linting via `flake8` as well as running tests with `unittest`.

Currently the `flake8` is set to lint only code found under the `please` directory, which does not yet exist. This is becasue we do not want to run the linter on the old/legacy code, and instead will run the linter and tests against only new code, to be committed in a package called `please` in future commits/PRs.

This is my first adventure with Github Actions, so there might be some pain points along the way to getting this fully working.